### PR TITLE
ci: add main branch to workflow triggers

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master, next ]
+    branches: [ main, master, next ]
   pull_request:
-    branches: [ master, next ]
+    branches: [ main, master, next ]
 
 jobs:
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master, next ]
+    branches: [ main, master, next ]
   pull_request:
-    branches: [ master, next ]
+    branches: [ main, master, next ]
 
 jobs:
   build:


### PR DESCRIPTION
The existing workflows only trigger on `master` and `next` branches, but the default branch is `main`. This adds `main` to the trigger list so PRs targeting `main` will run CI checks.